### PR TITLE
Fix for spotify song shortening

### DIFF
--- a/src/components/Spotify.jsx
+++ b/src/components/Spotify.jsx
@@ -47,7 +47,7 @@ export default class Spotify extends React.Component {
 
             // -- Trim Feature List, Etc. -- //
             let songName = info['song'];
-            if (cfg.shortenSong) {
+            if (cfg.shortenSong && songName.substring(0, songName.indexOf('(') > 0) {
                 songName = songName.substring(0, songName.indexOf('(')).trim()
             }
 


### PR DESCRIPTION
For: https://github.com/MrGVSV/mybar/issues/3

Song names will not show if they do not have a '(' due to return value being -1 if '(' not found causing trim to delete the entire song name.